### PR TITLE
Suggest using normal indent for parameters rather than indenting to opening brace.

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ RingRevenue Ruby Style Guide initially forked from https://github.com/bbatsov/ru
     end
     ```
 
-* Align the parameters of a method call if they span over multiple lines.
+* Align the parameters of a method call if they span over multiple lines using normal indent.
 
     ```Ruby
     # starting point (line is too long)
@@ -112,7 +112,7 @@ RingRevenue Ruby Style Guide initially forked from https://github.com/bbatsov/ru
       Mailer.deliver(to: 'bob@example.com', from: 'us@example.com', subject: 'Important message', body: source.text)
     end
 
-    # bad (normal indent)
+    # good (normal indent)
     def send_mail(source)
       Mailer.deliver(
         to: 'bob@example.com',
@@ -130,7 +130,7 @@ RingRevenue Ruby Style Guide initially forked from https://github.com/bbatsov/ru
           body: source.text)
     end
 
-    # good
+    # bad
     def send_mail(source)
       Mailer.deliver(to: 'bob@example.com',
                      from: 'us@example.com',


### PR DESCRIPTION
Indenting to opening brace can make lines way longer than 120 char, can be difficult to read on smaller screens, and param lists within param lists get strung out and more difficult to read.

See performance_mailer.rb for examples of long nested params within nested params.
